### PR TITLE
Remove redundant md5 expansions

### DIFF
--- a/src/CryptoJsAes.php
+++ b/src/CryptoJsAes.php
@@ -46,14 +46,8 @@ class CryptoJsAes
         $iv = hex2bin($json["iv"]);
         $ct = base64_decode($json["ct"]);
         $concatedPassphrase = $passphrase . $salt;
-        $md5 = [];
-        $md5[0] = md5($concatedPassphrase, true);
-        $result = $md5[0];
-        for ($i = 1; $i < 3; $i++) {
-            $md5[$i] = md5($md5[$i - 1] . $concatedPassphrase, true);
-            $result .= $md5[$i];
-        }
-        $key = substr($result, 0, 32);
+        $key = md5($concatedPassphrase, true);
+        $key .= md5($key . $concatedPassphrase, true);
         $data = openssl_decrypt($ct, 'aes-256-cbc', $key, true, $iv);
         return json_decode($data, true);
     }


### PR DESCRIPTION
We only need 32 bytes of key material, so generating 64 is a waste of cycles.